### PR TITLE
Bug in supporting primary key at non-root keypath in response dictionary

### DIFF
--- a/Source/MMRecord/MMRecordRepresentation.m
+++ b/Source/MMRecord/MMRecordRepresentation.m
@@ -114,7 +114,7 @@
         id value = nil;
         
         for (NSString *key in [primaryKeyRepresentation keyPaths]) {
-            value = [dictionary valueForKey:key];
+            value = [dictionary valueForKeyPath:key];
             
             if (value != nil) {
                 return value;


### PR DESCRIPTION
Conrad,

After debugging what we discussed yesterday a bit, I think I found the last root of the issue (after fixing the setup problems on my end :). In `MMRecordRepresentation` when it looks for the primary key of the response, it's using `valueForKey:` rather than `valueForKeyPath:` so our response wasn't getting mapped correctly to the existing record. In the testing I've done so far, the content of this PR seems to be enough to get us up and running.

Your thoughts?

john
