### PR TITLE
This pull request contains fix to MMRecord batch request issue

### DIFF
--- a/Source/MMRecord/MMRecord.m
+++ b/Source/MMRecord/MMRecord.m
@@ -550,6 +550,14 @@ NSString * const MMRecordAttributeAlternateNameKey = @"MMRecordAttributeAlternat
          if (state.failureBlock != nil) {
              state.failureBlock(error);
          }
+         
+         if ([state isBatched]) {
+             dispatch_group_leave(state.dispatchGroup);
+         }
+         
+#if NEEDS_DISPATCH_RETAIN_RELEASE
+         dispatch_release(state.dispatchGroup);
+#endif
      }];
     
     [self restoreDefaultOptions];


### PR DESCRIPTION
Problem : "startBatchedRequest.." method is failing to call completionBlock(), when one/all of the API call gets failed. 
Solution: I gone through the MMRecord batch request code and found that MMRecord is not calling "dispatch_group_leave(state.dispatchGroup);" in faillure block. In this pull request I have added code which informs the DispatchGroup that task has been completed by calling "dispatch_group_leave", this way completionBlock() is getting called when all of its batch request completes their execution regardless of their results.
