### PR TITLE
Fixing nil response object

### DIFF
--- a/Source/MMRecord/MMRecord.m
+++ b/Source/MMRecord/MMRecord.m
@@ -775,6 +775,10 @@ NSString * const MMRecordAttributeAlternateNameKey = @"MMRecordAttributeAlternat
         recordResponseObject = [responseObject valueForKeyPath:keyPathForResponseObject];
     }
     
+    if (recordResponseObject == nil || [recordResponseObject isKindOfClass:[NSNull class]]) {
+        recordResponseObject = [NSArray array];
+    }
+    
     if ([recordResponseObject isKindOfClass:[NSArray class]] == NO) {
         recordResponseObject = [NSArray arrayWithObject:recordResponseObject];
     }


### PR DESCRIPTION
If for some reason the response object does not contain the keypPathForResults specified by your managed object, it will now just return an empty array rather than crash.
