### PR TITLE
Performance Enhancements

### DIFF
--- a/Source/MMRecord/MMRecordResponse.m
+++ b/Source/MMRecord/MMRecordResponse.m
@@ -329,7 +329,9 @@
 }
 
 - (void)addProtoRecord:(MMRecordProtoRecord *)protoRecord {
-    [self.protoRecords addObject:protoRecord];
+    if (![self.prototypeDictionary objectForKey:protoRecord.primaryKeyValue]) {
+        [self.protoRecords addObject:protoRecord];
+    }
 }
 
 - (void)addProtoRecordToDictionary:(MMRecordProtoRecord *)protoRecord {


### PR DESCRIPTION
I've moved the prototype dictionary into MMRecordResponseGroup as suggested and also used a similar method to increase the performance of performFetchForAllRecordsAndAssociateWithProtosInContext without using additional NSFetchRequest's.
