### PR TITLE
Supports subclassing Entities to an arbitrary depth, and on relationship entities

### DIFF
--- a/Source/MMRecord/MMRecordResponse.m
+++ b/Source/MMRecord/MMRecordResponse.m
@@ -68,7 +68,6 @@
 @property (nonatomic, copy) NSArray *responseObjectArray;
 @property (nonatomic, strong) NSMutableArray *objectGraph;  // Array of Protos
 @property (nonatomic, strong) NSMutableDictionary *responseGroups;  // Key = NSEntityDescription, Value = MMRecordResponseGroup
-- (NSEntityDescription *)mostSpecificEntityForResponseObject:(id)object withInitialEntity:(NSEntityDescription *)initialEntity;
 @end
 
 
@@ -164,8 +163,8 @@
 
 #pragma mark - Determine Entity subclass to use
 
-- (NSEntityDescription *)mostSpecificEntityForResponseObject:(id)object
-                                           withInitialEntity:(NSEntityDescription *)initialEntity{
+- (NSEntityDescription *)subEntityForRecordResponseObject:(id)object
+                                           withInitialEntity:(NSEntityDescription *)initialEntity {
     NSArray *subEntities = initialEntity.subentities;
 
     for (NSEntityDescription *subEntity in subEntities) {
@@ -173,7 +172,7 @@
 
         if ([subEntityClass respondsToSelector:@selector(shouldUseSubEntityRecordClassToRepresentData:)]) {
             if ([subEntityClass shouldUseSubEntityRecordClassToRepresentData:object]) {
-                return [self mostSpecificEntityForResponseObject:object withInitialEntity:subEntity];
+                return [self subEntityForRecordResponseObject:object withInitialEntity:subEntity];
             }
         }
     }
@@ -188,7 +187,7 @@
     
 
     for (id recordResponseObject in self.responseObjectArray) {
-        NSEntityDescription *entity = [self mostSpecificEntityForResponseObject:recordResponseObject
+        NSEntityDescription *entity = [self subEntityForRecordResponseObject:recordResponseObject
                                                               withInitialEntity:self.initialEntity];
         
         MMRecordProtoRecord *proto = [self protoRecordWithRecordResponseObject:recordResponseObject
@@ -285,11 +284,11 @@
             for (id object in relationshipObject) {
                 if ([protoRecord canAccomodateAdditionalProtoRecordForRelationshipDescription:relationshipDescription]) {
 
-                    NSEntityDescription *mostSpecificSubEntity= [self mostSpecificEntityForResponseObject:object
-                                                                                        withInitialEntity:entity];
+                    NSEntityDescription *recordSubEntity = [self subEntityForRecordResponseObject:object
+                                                                                withInitialEntity:entity];
 
                     MMRecordProtoRecord *relationshipProto = [self protoRecordWithRecordResponseObject:object
-                                                                                                entity:mostSpecificSubEntity
+                                                                                                entity:recordSubEntity
                                                                                 existingResponseGroups:responseGroups
                                                                                      parentProtoRecord:protoRecord];
                     


### PR DESCRIPTION
nb: first of all, apologies for the white-space deletions, my IDE cleaned them up. I can resubmit without, if that's much easier.

I extended the extent to which MMRecord detects and uses Entity subclasses ( i.e. when it queries `shouldUseSubEntityRecordClassToRepresentData`). It now supports beyond a single level of subclassing (i.e. it checks recursively), and also allows _relationship_ entities to be matched to a subclass as well, as in this example:

A: it will now support Account subclassing for the following example:

```
{
    "client": {
        "portfolios":{
            "accounts":[
                {
                    "account_id": 123,
                    "account_name": "Joe Bloggs",
                    "account_type": "current-account"
                },
                {
                    "account_id": 456,
                    "account_name": "Joe Bloggs",
                    "account_type": "savings-account"
                }
            ]
        }
    }
}
```

Feedback is very welcome 
