### PR TITLE
Changed server response handling from NSException to NSError

### DIFF
--- a/Source/AFMMRecordResponseSerializer/AFMMRecordResponseSerializer.m
+++ b/Source/AFMMRecordResponseSerializer/AFMMRecordResponseSerializer.m
@@ -132,11 +132,11 @@ NSString * const AFMMRecordResponseSerializerWithDataKey = @"AFMMRecordResponseS
     }
     
     // Verify that the server responded in an expected manner.
-    if (!([responseObject isKindOfClass:[NSDictionary class]] ||
-          [responseObject isKindOfClass:[NSArray class]])) {
+    if (!([responseObject isKindOfClass:[NSDictionary class]]) &&
+        !([responseObject isKindOfClass:[NSArray class]])) {
 
         (*error) = [MMRecord errorWithMMRecordCode:MMRecordErrorCodeInvalidResponseFormat
-                                       description:@"Response object should be of type array or dictionary"];
+                                       description:[NSString stringWithFormat:@"The response object should be an array or dictionary. The returned response object type was: %@", NSStringFromClass([responseObject class])]];
 
         return nil;
     }

--- a/Source/MMRecord/MMRecord.m
+++ b/Source/MMRecord/MMRecord.m
@@ -1039,7 +1039,7 @@ NSString * const MMRecordAttributeAlternateNameKey = @"MMRecordAttributeAlternat
             break;
         case MMRecordErrorCodeInvalidResponseFormat:
             result = NSLocalizedString(@"Invalid Response Format.",
-                                       @"The server responded in a manner which could not be processed by the serializer.");
+                                       @"The server response was in an unexpected format that could not be handled by MMRecord.");
             break;
         default:
         case MMRecordErrorCodeUnknown:


### PR DESCRIPTION
If the server were to return something unexpected, it is often recoverable; as an NSException the app would simply crash.
