### PR TITLE
Move primaryKey injection earlier

### DIFF
--- a/Source/MMRecord/MMRecordProtoRecord.h
+++ b/Source/MMRecord/MMRecordProtoRecord.h
@@ -132,7 +132,8 @@
  */
 + (MMRecordProtoRecord *)protoRecordWithDictionary:(NSDictionary *)dictionary
                                             entity:(NSEntityDescription *)entity
-                                    representation:(MMRecordRepresentation *)representation;
+                                    representation:(MMRecordRepresentation *)representation
+                                   primaryKeyValue:(id)primaryKeyValue;
 
 
 ///---------------------------

--- a/Source/MMRecord/MMRecordProtoRecord.m
+++ b/Source/MMRecord/MMRecordProtoRecord.m
@@ -39,12 +39,13 @@
 
 + (MMRecordProtoRecord *)protoRecordWithDictionary:(NSDictionary *)dictionary
                                             entity:(NSEntityDescription *)entity
-                                    representation:(MMRecordRepresentation *)representation {
+                                    representation:(MMRecordRepresentation *)representation
+                                   primaryKeyValue:(id)primaryKeyValue {
     NSParameterAssert([NSClassFromString([entity managedObjectClassName]) isSubclassOfClass:[MMRecord class]]);
     MMRecordProtoRecord *protoRecord = [[MMRecordProtoRecord alloc] init];
     protoRecord.dictionary = dictionary;
     protoRecord.entity = entity;
-    protoRecord.primaryKeyValue = [representation primaryKeyValueFromDictionary:dictionary];
+    protoRecord.primaryKeyValue = primaryKeyValue;
     protoRecord.relationshipProtosDictionary = [NSMutableDictionary dictionary];
     protoRecord.relationshipDescriptionsDictionary = [NSMutableDictionary dictionary];
     protoRecord.hasRelationshipPrimarykey = [representation hasRelationshipPrimaryKey];


### PR DESCRIPTION
Fixes #91. Move primaryKey injection earlier so it can successfully find/merge duplicate objects within a response.  This involved a bit of refactoring to do cleanly.
