### PR TITLE
Add hooks to allow subclasses to override block based components of MMRecordOptions

### DIFF
--- a/Source/MMRecord/MMRecord.h
+++ b/Source/MMRecord/MMRecord.h
@@ -263,6 +263,19 @@ typedef id<NSCopying> (^MMRecordOptionsEntityPrimaryKeyInjectionBlock)(NSEntityD
  */
 typedef void (^MMRecordOptionsRecordPrePopulationBlock)(MMRecordProtoRecord *protoRecord);
 
+/**
+ This block may be used for inserting custom logic into the record population workflow. This block,
+ if defined, will be executed immediately after the MMRecordMarshaler's -populateProtoRecord: method.
+ 
+ @warning This block should only be used in relatively rare cases. It is not a substitute for proper
+ model configuration or for marshaler/representation subclassing. It is meant for rare cases where
+ post processing data into the population flow is required for accurate record population. Because this
+ block will be executed for each proto record for a given request, performance issues may arrise.
+ Please use caution.
+ @param protoRecord The proto record which has just been populated.
+ */
+typedef void (^MMRecordOptionsRecordPostPopulationBlock)(MMRecordProtoRecord *protoRecord);
+
 
 @interface MMRecord : NSManagedObject
 
@@ -385,6 +398,13 @@ typedef void (^MMRecordOptionsRecordPrePopulationBlock)(MMRecordProtoRecord *pro
  */
 + (MMRecordOptionsRecordPrePopulationBlock)recordPrePopulationBlock;
 
+/**
+ This method returns a block that will be executed immediately after record
+ population in order to perform some task like building derived attributes.
+ 
+ @discussion The default implementation of this method returns nil (no block).
+ */
++ (MMRecordOptionsRecordPostPopulationBlock)recordPostPopulationBlock;
 
 ///-----------------------------------------------
 /// @name Setting and Accessing the MMServer Class
@@ -738,6 +758,14 @@ typedef void (^MMRecordOptionsRecordPrePopulationBlock)(MMRecordProtoRecord *pro
  @discussion Default value is nil which means population will be performed normally.
  */
 @property (nonatomic, copy) MMRecordOptionsRecordPrePopulationBlock recordPrePopulationBlock;
+
+/**
+ This option allows you to specify a block that will be executed immediately after record
+ population in order to perform some task like creating dervied data.
+ 
+ @discussion Default value is nil which means population will be performed normally.
+ */
+@property (nonatomic, copy) MMRecordOptionsRecordPostPopulationBlock recordPostPopulationBlock;
 
 @end
 

--- a/Source/MMRecord/MMRecord.h
+++ b/Source/MMRecord/MMRecord.h
@@ -400,7 +400,8 @@ typedef void (^MMRecordOptionsRecordPostPopulationBlock)(MMRecordProtoRecord *pr
 
 /**
  This method returns a block that will be executed immediately after record
- population in order to perform some task like building derived attributes.
+ population and relationships are estabished in order to perform some 
+ task like building derived attributes.
  
  @discussion The default implementation of this method returns nil (no block).
  */
@@ -761,7 +762,7 @@ typedef void (^MMRecordOptionsRecordPostPopulationBlock)(MMRecordProtoRecord *pr
 
 /**
  This option allows you to specify a block that will be executed immediately after record
- population in order to perform some task like creating dervied data.
+ population and relationships are established in order to perform some task like creating dervied data.
  
  @discussion Default value is nil which means population will be performed normally.
  */

--- a/Source/MMRecord/MMRecord.m
+++ b/Source/MMRecord/MMRecord.m
@@ -149,6 +149,10 @@ NSString * const MMRecordAttributeAlternateNameKey = @"MMRecordAttributeAlternat
     return nil;
 }
 
++ (MMRecordOptionsRecordPostPopulationBlock)recordPostPopulationBlock {
+    return nil;
+}
+
 #pragma mark - Request Options Configuration Methods
 
 + (void)setOptions:(MMRecordOptions *)options {
@@ -176,6 +180,7 @@ NSString * const MMRecordAttributeAlternateNameKey = @"MMRecordAttributeAlternat
     options.deleteOrphanedRecordBlock = [self deleteOrphanedRecordBlock];
     options.entityPrimaryKeyInjectionBlock = [self entityPrimaryKeyInjectionBlock];
     options.recordPrePopulationBlock = [self recordPrePopulationBlock];
+    options.recordPostPopulationBlock = [self recordPostPopulationBlock];
     return options;
 }
 

--- a/Source/MMRecord/MMRecord.m
+++ b/Source/MMRecord/MMRecord.m
@@ -137,6 +137,17 @@ NSString * const MMRecordAttributeAlternateNameKey = @"MMRecordAttributeAlternat
     return NO;
 }
 
++ (MMRecordOptionsEntityPrimaryKeyInjectionBlock)entityPrimaryKeyInjectionBlock {
+    return nil;
+}
+
++ (MMRecordOptionsDeleteOrphanedRecordBlock)deleteOrphanedRecordBlock {
+    return nil;
+}
+
++ (MMRecordOptionsRecordPrePopulationBlock)recordPrePopulationBlock {
+    return nil;
+}
 
 #pragma mark - Request Options Configuration Methods
 
@@ -162,9 +173,9 @@ NSString * const MMRecordAttributeAlternateNameKey = @"MMRecordAttributeAlternat
     options.pageManagerClass = [[self server] pageManagerClass];
     options.debugger = [[MMRecordDebugger alloc] init];
     options.debugger.loggingLevel = [self loggingLevel];
-    options.deleteOrphanedRecordBlock = nil;
-    options.entityPrimaryKeyInjectionBlock = nil;
-    options.recordPrePopulationBlock = nil;
+    options.deleteOrphanedRecordBlock = [self deleteOrphanedRecordBlock];
+    options.entityPrimaryKeyInjectionBlock = [self entityPrimaryKeyInjectionBlock];
+    options.recordPrePopulationBlock = [self recordPrePopulationBlock];
     return options;
 }
 

--- a/Source/MMRecord/MMRecordResponse.m
+++ b/Source/MMRecord/MMRecordResponse.m
@@ -41,6 +41,7 @@
 @property (nonatomic, strong) MMRecordRepresentation *representation;
 @property (nonatomic) BOOL hasRelationshipPrimaryKey;
 @property (nonatomic, copy) MMRecordOptionsRecordPrePopulationBlock recordPrePopulationBlock;
+@property (nonatomic, copy) MMRecordOptionsRecordPostPopulationBlock recordPostPopulationBlock;
 @property (nonatomic, strong) MMRecordDebugger *debugger;
 
 - (instancetype)initWithEntity:(NSEntityDescription *)entity;
@@ -147,6 +148,7 @@
         if ([NSClassFromString([entity managedObjectClassName]) isSubclassOfClass:[MMRecord class]]) {
             responseGroup = [[MMRecordResponseGroup alloc] initWithEntity:entity];
             responseGroup.recordPrePopulationBlock = self.options.recordPrePopulationBlock;
+            responseGroup.recordPostPopulationBlock = self.options.recordPostPopulationBlock;
             responseGroup.debugger = self.options.debugger;
             responseGroups[entityDescriptionsKey] = responseGroup;
         } else {
@@ -424,6 +426,10 @@
         }
         
         [self.representation.marshalerClass populateProtoRecord:protoRecord];
+
+        if (self.recordPostPopulationBlock != nil) {
+            self.recordPostPopulationBlock(protoRecord);
+        }
     }
 }
 

--- a/Source/MMRecord/MMRecordResponse.m
+++ b/Source/MMRecord/MMRecordResponse.m
@@ -416,6 +416,10 @@
 - (void)establishRelationshipsForAllRecords {
     for (MMRecordProtoRecord *protoRecord in self.protoRecords) {
         [self.representation.marshalerClass establishRelationshipsOnProtoRecord:protoRecord];
+
+        if (self.recordPostPopulationBlock != nil) {
+            self.recordPostPopulationBlock(protoRecord);
+        }
     }
 }
 
@@ -426,10 +430,6 @@
         }
         
         [self.representation.marshalerClass populateProtoRecord:protoRecord];
-
-        if (self.recordPostPopulationBlock != nil) {
-            self.recordPostPopulationBlock(protoRecord);
-        }
     }
 }
 


### PR DESCRIPTION
I added some hooks in to MMRecord so that subclasses could provide the blocks used in MMRecordOptions.  The change is pretty minimal and works like the other existing properties, like keyPathForResponseObject.  By default, the initial values are still nil, so it should have no impact on existing code.

The motivation for this is to provide these block to AFMMRecordResponseSerializer on a class by class basis.  Previously, you could only provide one block to AFMMRecordResponseSerializer that got used for everything.  Now a subclass can override entityPrimaryKeyInjectionBlock and that'll get used by entityPrimaryKeyInjectionBlock.
