### PR TITLE
Propagate HTTP errors in AFMMRecordResponseSerializer

### DIFF
--- a/Source/AFMMRecordResponseSerializer/AFMMRecordResponseSerializer.m
+++ b/Source/AFMMRecordResponseSerializer/AFMMRecordResponseSerializer.m
@@ -149,6 +149,8 @@ NSString * const AFMMRecordResponseSerializerWithDataKey = @"AFMMRecordResponseS
                                                 code:(*error).code
                                             userInfo:userInfo];
         (*error) = newError;
+
+        return nil;
     }
     
     NSEntityDescription *initialEntity = [self.entityMapper recordResponseSerializer:self

--- a/Source/MMRecord/MMRecordResponse.m
+++ b/Source/MMRecord/MMRecordResponse.m
@@ -401,14 +401,16 @@
 #pragma mark - Record Building
 
 - (void)obtainRecordsForProtoRecordsInContext:(NSManagedObjectContext *)context {
-    // Phase 1: Fetch
-    [self performFetchForAllRecordsAndAssociateWithProtosInContext:context];
-    
-    // Phase 2: Wonky Stuff with Relationship Primary Keys
-    [self associateRelationshipPrimaryKeyRecordProtosIfNecesary];
-    
-    // Phase 3: Create
-    [self createRecordsForProtoRecordsWithMissingRecordsInContext:context];
+    [context performBlockAndWait:^{
+        // Phase 1: Fetch
+        [self performFetchForAllRecordsAndAssociateWithProtosInContext:context];
+
+        // Phase 2: Wonky Stuff with Relationship Primary Keys
+        [self associateRelationshipPrimaryKeyRecordProtosIfNecesary];
+
+        // Phase 3: Create
+        [self createRecordsForProtoRecordsWithMissingRecordsInContext:context];
+    }];
 }
 
 - (void)establishRelationshipsForAllRecords {


### PR DESCRIPTION
AFMMRecordResponseSerializer was silently swallowing all errors from the
HTTPResponseSerializer and attempting to parse responses regardless.

Fix by returning nil as the response object while the correct error is set.