### PR TITLE
Propagate HTTP errors in AFMMRecordResponseSerializer

### DIFF
--- a/Source/AFMMRecordResponseSerializer/AFMMRecordResponseSerializer.m
+++ b/Source/AFMMRecordResponseSerializer/AFMMRecordResponseSerializer.m
@@ -149,6 +149,8 @@ NSString * const AFMMRecordResponseSerializerWithDataKey = @"AFMMRecordResponseS
                                                 code:(*error).code
                                             userInfo:userInfo];
         (*error) = newError;
+
+        return nil;
     }
     
     NSEntityDescription *initialEntity = [self.entityMapper recordResponseSerializer:self


### PR DESCRIPTION
AFMMRecordResponseSerializer was silently swallowing all errors from the
HTTPResponseSerializer and attempting to parse responses regardless.

Fix by returning nil as the response object while the correct error is set.
