### PR TITLE
Check for NULL before setting a primary key value for a child entity

### DIFF
--- a/Source/MMRecord/MMRecordMarshaler.m
+++ b/Source/MMRecord/MMRecordMarshaler.m
@@ -71,7 +71,7 @@
         onRecord:(MMRecord *)record
        attribute:(NSAttributeDescription *)attribute
    dateFormatter:(NSDateFormatter *)dateFormatter {
-    if (value == nil) {
+    if (value == nil || value == [NSNull null]) {
         return;
     }
     


### PR DESCRIPTION
Parent responses having a child with its primary key as NULL causes an exception.

Solution: Check for nil and null both before setting the primary key value to the child entity