### PR TITLE
Fixing issue #112 w/GCC_NO_COMMON_BLOCKS build setting

### DIFF
--- a/Examples/MMRecordAppDotNet/MMRecordAppDotNet.xcodeproj/project.pbxproj
+++ b/Examples/MMRecordAppDotNet/MMRecordAppDotNet.xcodeproj/project.pbxproj
@@ -777,6 +777,7 @@
 		55F95200165C73460060851E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MMRecordAppDotNet/MMRecordAppDotNet-Prefix.pch";
 				INFOPLIST_FILE = "MMRecordAppDotNet/MMRecordAppDotNet-Info.plist";
@@ -790,6 +791,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MMRecordAppDotNet/MMRecordAppDotNet-Prefix.pch";
 				INFOPLIST_FILE = "MMRecordAppDotNet/MMRecordAppDotNet-Info.plist";

--- a/Examples/MMRecordAppDotNet/MMRecordAppDotNet/ADNPostsViewController.m
+++ b/Examples/MMRecordAppDotNet/MMRecordAppDotNet/ADNPostsViewController.m
@@ -22,7 +22,6 @@
 
 @property (nonatomic, strong) ADNPostManager *postManager;
 @property (nonatomic, copy) NSArray *posts;
-@property (nonatomic, strong) UIRefreshControl *refreshControl;
 
 @end
 

--- a/Examples/MMRecordAtlassian/MMRecordAtlassian.xcodeproj/project.pbxproj
+++ b/Examples/MMRecordAtlassian/MMRecordAtlassian.xcodeproj/project.pbxproj
@@ -415,6 +415,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = MMRecordAtlassian/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -427,6 +428,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = MMRecordAtlassian/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Examples/MMRecordFoursquare/MMRecordFoursquare/MMRecordFoursquare.xcodeproj/project.pbxproj
+++ b/Examples/MMRecordFoursquare/MMRecordFoursquare/MMRecordFoursquare.xcodeproj/project.pbxproj
@@ -701,6 +701,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MMRecordFoursquare/MMRecordFoursquare-Prefix.pch";
 				INFOPLIST_FILE = "MMRecordFoursquare/MMRecordFoursquare-Info.plist";
@@ -715,6 +716,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MMRecordFoursquare/MMRecordFoursquare-Prefix.pch";
 				INFOPLIST_FILE = "MMRecordFoursquare/MMRecordFoursquare-Info.plist";

--- a/Examples/MMRecordInstagram/MMRecordInstagram.xcodeproj/project.pbxproj
+++ b/Examples/MMRecordInstagram/MMRecordInstagram.xcodeproj/project.pbxproj
@@ -650,6 +650,7 @@
 		9FABD8DA16FA7DC700184BA5 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MMRecordInstagram/Source/MMRecordInstagram-Prefix.pch";
 				INFOPLIST_FILE = "MMRecordInstagram/SupportingFiles/MMRecordInstagram-Info.plist";
@@ -666,6 +667,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MMRecordInstagram/Source/MMRecordInstagram-Prefix.pch";
 				INFOPLIST_FILE = "MMRecordInstagram/SupportingFiles/MMRecordInstagram-Info.plist";

--- a/Examples/MMRecordPerformance/MMRecordPerformance.xcodeproj/project.pbxproj
+++ b/Examples/MMRecordPerformance/MMRecordPerformance.xcodeproj/project.pbxproj
@@ -653,6 +653,7 @@
 		55F95200165C73460060851E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MMRecordAppDotNet/MMRecordPerformance-Prefix.pch";
 				INFOPLIST_FILE = "MMRecordAppDotNet/MMRecordPerformance-Info.plist";
@@ -666,6 +667,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MMRecordAppDotNet/MMRecordPerformance-Prefix.pch";
 				INFOPLIST_FILE = "MMRecordAppDotNet/MMRecordPerformance-Info.plist";

--- a/Examples/MMRecordTwitter/MMRecordTwitter.xcodeproj/project.pbxproj
+++ b/Examples/MMRecordTwitter/MMRecordTwitter.xcodeproj/project.pbxproj
@@ -579,6 +579,7 @@
 		55C6BD1C16FD5416000114DF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MMRecordTwitter/MMRecordTwitter-Prefix.pch";
 				INFOPLIST_FILE = "MMRecordTwitter/MMRecordTwitter-Info.plist";
@@ -592,6 +593,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MMRecordTwitter/MMRecordTwitter-Prefix.pch";
 				INFOPLIST_FILE = "MMRecordTwitter/MMRecordTwitter-Info.plist";

--- a/Source/MMRecord/MMRecord.m
+++ b/Source/MMRecord/MMRecord.m
@@ -795,7 +795,7 @@ NSString * const MMRecordAttributeAlternateNameKey = @"MMRecordAttributeAlternat
     
     NSError *coreDataError = nil;
     if ([backgroundContext save:&coreDataError] == NO) {
-        NSString *coreDataErrorString = [NSString stringWithFormat:@"Core Data error occurred with code: %d, description: %@",
+        NSString *coreDataErrorString = [NSString stringWithFormat:@"Core Data error occurred with code: %zd, description: %@",
                                                                    coreDataError.code,
                                                                    coreDataError.localizedDescription];
         NSString *errorDescription = [NSString stringWithFormat:@"Unable to save background context while populating records. MMRecord import operation unsuccessful. %@",

--- a/Source/MMRecord/MMRecordDebugger.h
+++ b/Source/MMRecord/MMRecordDebugger.h
@@ -39,7 +39,7 @@ typedef NS_ENUM(NSInteger, MMRecordLoggingLevel) {
 };
 
 // MMRecordErrorDomain is the domain used for all errors created and returned by MMRecordDebugger
-NSString * const MMRecordErrorDomain;
+FOUNDATION_EXTERN NSString * const MMRecordErrorDomain;
 
 /**
  MMRecordDebuggerKey can be used to access the instance of MMRecordDebugger on
@@ -47,7 +47,7 @@ NSString * const MMRecordErrorDomain;
  errors encountered on the population process, as well as metadata about the
  request itself, including the response object and initial entity.
  */
-NSString * const MMRecordDebuggerKey;
+FOUNDATION_EXTERN NSString * const MMRecordDebuggerKey;
 
 /**
  MMRecordDebuggerParameters are keys used to pass information along to
@@ -59,14 +59,14 @@ NSString * const MMRecordDebuggerKey;
  an error's userInfo dictionary if those objects have been passed into the
  handleErrorCode:withParameters: method defined below.
  */
-NSString * const MMRecordDebuggerParameterErrorDescription;
-NSString * const MMRecordDebuggerParameterResponseObject;
-NSString * const MMRecordDebuggerParameterRecordClassName;
-NSString * const MMRecordDebuggerParameterKeyPathForResponseObject;
-NSString * const MMRecordDebuggerParameterEntityDescription;
-NSString * const MMRecordDebuggerParameterPropertyName;
-NSString * const MMRecordDebuggerParameterRecordDictionary;
-NSString * const MMRecordDebuggerParameterServerClassName;
+FOUNDATION_EXTERN NSString * const MMRecordDebuggerParameterErrorDescription;
+FOUNDATION_EXTERN NSString * const MMRecordDebuggerParameterResponseObject;
+FOUNDATION_EXTERN NSString * const MMRecordDebuggerParameterRecordClassName;
+FOUNDATION_EXTERN NSString * const MMRecordDebuggerParameterKeyPathForResponseObject;
+FOUNDATION_EXTERN NSString * const MMRecordDebuggerParameterEntityDescription;
+FOUNDATION_EXTERN NSString * const MMRecordDebuggerParameterPropertyName;
+FOUNDATION_EXTERN NSString * const MMRecordDebuggerParameterRecordDictionary;
+FOUNDATION_EXTERN NSString * const MMRecordDebuggerParameterServerClassName;
 
 
 /**


### PR DESCRIPTION
New GCC_NO_COMMON_BLOCKS setting recommended in Xoode 6.3 breaks anything that imports MMRecordDebugging since these constants were defined without `extern`.