### PR TITLE
Reason: mutableOrderedSetValueForKey and mutableSetValueForKey now re…

### DIFF
--- a/Source/MMRecord/MMRecordMarshaler.m
+++ b/Source/MMRecord/MMRecordMarshaler.m
@@ -198,9 +198,9 @@
         useOrderedSet = relationship.isOrdered ? YES : NO;
     }
     if (useOrderedSet) {
-        relationshipSet = [fromRecord mutableOrderedSetValueForKey:[relationship name]];
+        relationshipSet = [NSMutableOrderedSet orderedSetWithOrderedSet:[fromRecord mutableOrderedSetValueForKey:[relationship name]]];
     } else {
-        relationshipSet = [fromRecord mutableSetValueForKey:[relationship name]];
+        relationshipSet = [NSMutableSet setWithSet:[fromRecord mutableSetValueForKey:[relationship name]]];
     }
     
     [relationshipSet addObject:toRecord];


### PR DESCRIPTION
…turns a proxy set and therefore the returned value is not a backing storage and therefore all the calls that tries to add object are forwarded it to backing storage, while setValue:forKey: will set it to an empty set

Solution: Adding the values to a real set and setting that in setValue:forKey: